### PR TITLE
create sockets per IPM2 instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,6 @@ var axon = require('axon');
 var cst  = require('../constants.js');
 var sys  = require('sys');
 var rpc  = require('axon-rpc');
-var sub  = axon.socket('sub-emitter');
-var req  = axon.socket("req");
 var log  = require('debug')('pm2:interface');
 var EventEmitter = require('events').EventEmitter;
 
@@ -37,9 +35,11 @@ var IPM2 = function(sub_port, rpc_port, bind_host) {
   this.rpc_port  = rpc_port;
   this.bind_host = bind_host;
 
+  var sub = axon.socket('sub-emitter');
   this.sub_sock = sub_sock = sub.connect(sub_port, bind_host);
   this.bus      = sub;
 
+  var req = axon.socket("req");
   this.rpc_sock = rpc_sock = req.connect(rpc_port, bind_host);
   this.rpc_client = new rpc.Client(req);
 


### PR DESCRIPTION
If you create the sockets as file scoped variables, they will be reused by every instance of IPM2.

So if I do:

``` javascript
var pm2Interface = require('pm2-interface');

var imp2a = pm2Interface({bind_host: 'localhost'});
var imp2b = pm2Interface({bind_host: 'some.remote.host'});
```

`imp2a` and `imp2b` actually share event and rpc sockets which is probably not what was intended.

The change I've made moves the socket creation into the IPM2 constructor so that in the above example both connections would have their own sockets.
