### PR TITLE
axon/axon-rpc events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Dependencies
  */
@@ -85,31 +84,36 @@ var IPM2 = function(sub_port, rpc_port, bind_host) {
    * and RPC
    */
 
-  rpc_sock.on('close', function() {
-    log('Connection closed');
-    self.emit('closed');
-  });
-
   rpc_sock.on('connect', function() {
-    log('RPC Connected');
-
+    log('rpc_sock:ready');
     generateMethods(function() {
-      self.emit('ready');
+      self.emit('rpc_sock:ready');
     });
   });
 
+  rpc_sock.on('close', function() {
+    log('rpc_sock:closed');
+    self.emit('rpc_sock:closed');
+  });
+    
+  rpc_sock.on('reconnect attempt', function() {
+    log('rpc_sock:reconnecting');
+    self.emit('rpc_sock:reconnecting');
+  });
+  
   sub_sock.on('connect', function() {
-    log('PubSub Connected');
+    log('sub_sock ready');
+    self.emit('sub_sock:ready');
   });
-
-  sub_sock.on('disconnect', function() {
-    log('Error4');
-    self.emit('close');
+  
+  sub_sock.on('close', function() {
+    log('sub_sock:closed');
+    self.emit('sub_sock:closed');
   });
-
+  
   sub_sock.on('reconnect attempt', function() {
-    log('Error5');
-    self.emit('reconnecting');
+    log('sub_sock:reconnecting');
+    self.emit('sub_sock:reconnecting');
   });
 
 };


### PR DESCRIPTION
This solves https://github.com/Unitech/pm2-interface/issues/4

the _disconnect_ event never gets fired:

```
sub_sock.on('disconnect', function() {
   //never
    log('Error4');
    self.emit('close');  //never .
  });
```

we need to listen the **close** event:

```
 sub_sock.on('close', function() { ... });
```

to test:

```
var ipm2 = require('pm2-interface')(); // ready events
ipm2.on('rpc_sock:ready', function() {
    console.log('rpc_sock:ready');
});
ipm2.on('rpc_sock:closed', function() {
    console.log('rpc_sock:closed');
});

ipm2.on('rpc_sock:reconnecting', function() {
    console.log('rpc_sock:reconnecting');
});
ipm2.on('sub_sock:ready', function() {
    console.log('sub_sock:ready');
});
ipm2.on('sub_sock:closed', function() {
    console.log('sub_sock:closed');
});

ipm2.on('sub_sock:reconnecting', function() {
    console.log('sub_sock:reconnecting');
});

ipm2.disconnect(); // close events
```

testing reconect events:

do `pm2 kill` and restart the process.
