### PR TITLE
Fix global variable leak

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,11 +35,11 @@ var IPM2 = function(sub_port, rpc_port, bind_host) {
   this.bind_host = bind_host;
 
   var sub = axon.socket('sub-emitter');
-  this.sub_sock = sub_sock = sub.connect(sub_port, bind_host);
+  var sub_sock = this.sub_sock = sub.connect(sub_port, bind_host);
   this.bus      = sub;
 
   var req = axon.socket("req");
-  this.rpc_sock = rpc_sock = req.connect(rpc_port, bind_host);
+  var rpc_sock = this.rpc_sock = req.connect(rpc_port, bind_host);
   this.rpc_client = new rpc.Client(req);
 
   this.rpc = {};
@@ -61,7 +61,8 @@ var IPM2 = function(sub_port, rpc_port, bind_host) {
     log('Requesting and generating RPC methods');
     self.rpc_client.methods(function(err, methods) {
       Object.keys(methods).forEach(function(key) {
-        var method_signature = md = methods[key];
+        var method_signature, md;
+        method_signature = md = methods[key];
 
         log('+-- Creating %s method', md.name);
 


### PR DESCRIPTION
Due to an error in their declaration, the variables `sub_sock`, `rpc_sock` and `md` leaks in the global scope.
