### PR TITLE
Fix socket discovery on computers using custom PM2_HOME

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -4,8 +4,7 @@
 //
 
 var p    = require('path');
-var HOME = process.env.PM2_HOME || process.env.HOME;
-var DEFAULT_FILE_PATH = p.resolve(HOME, '.pm2');
+var DEFAULT_FILE_PATH = process.env.PM2_HOME || p.resolve(process.env.HOME, '.pm2');
 
 module.exports = {
   DAEMON_BIND_HOST   : 'localhost',


### PR DESCRIPTION
I know that this interface library is discontinued, but I still find it very useful to getting logs out of pm2. I couldn't find a way to receive log stream on new official version. I would really appreciate if this patch could be included and published to npm registry. Thanks.
